### PR TITLE
Minor fix to OnEntityBuilt

### DIFF
--- a/source/includes/rust_api_hooks.md
+++ b/source/includes/rust_api_hooks.md
@@ -233,7 +233,7 @@
  * Called from KeyLock.OnTryToOpen and KeyLock.OnTryToClose
  * Returning true will allow door usage, nothing will by default will allow door usage, returning anything else will reject door usage
 
-### OnEntityBuilt(Planner planner, Construction component)
+### OnEntityBuilt(Planner planner, UnityEngine/GameObject component)
  * Called from Planner.DoBuild
  * No return behavior
  * Called when any structure is built (walls, ceilings, stairs, etc.)


### PR DESCRIPTION
Changed a bit too much in the previous PR. Only the first argument of the hook changed from HeldEntity to Planner, the second one is still a UnityEngine.GameObject