### PR TITLE
Fixed typo on Rust OnItemRepair hook

### DIFF
--- a/source/includes/rust/hooks_item.md
+++ b/source/includes/rust/hooks_item.md
@@ -191,7 +191,7 @@ void OnItemRepair(BasePlayer player, Item item)
 }
 ```
 
- * Called right after an item has been picked up
+ * Called right before an item is repaired
  * No return behavior
 
 ## OnItemResearch


### PR DESCRIPTION
Was reading through the docs and noticed this copy-paste typo.